### PR TITLE
Use `rAF` for queuing batched notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "keywords": [],
   "main": "src/index.tsx",
   "dependencies": {
-    "@reduxjs/toolkit": "1.9.0-rc.0",
+    "@reduxjs/toolkit": "1.9.0-rc.1",
     "@tanstack/react-query": "4.13.5",
     "react": "18.0.0",
     "react-dom": "18.0.0",

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,44 +1,46 @@
-import { 
-  configureStore,
- autoBatchEnhancer
-} from "@reduxjs/toolkit";
-import { createApi } from "@reduxjs/toolkit/query/react";
+import { configureStore, autoBatchEnhancer } from '@reduxjs/toolkit'
+import { createApi } from '@reduxjs/toolkit/query/react'
 
 export const config = {
   minimumRequestDuration: 50,
   maximumRequestDuration: 100,
-  requestsPerArg: {} as Record<string, number>
-};
+  requestsPerArg: {} as Record<string, number>,
+}
 
 export const baseQuery = (arg: string) => {
-  return new Promise<{ data: string }>(resolve => {
+  return new Promise<{ data: string }>((resolve) => {
     config.requestsPerArg[arg] ??= 0
     const nextNumber = ++config.requestsPerArg[arg]
-    const duration = config.minimumRequestDuration + Math.random() * (config.maximumRequestDuration - config.minimumRequestDuration)
-    setTimeout(() => resolve({data: `${arg}${nextNumber}`}), duration)
+    const duration =
+      config.minimumRequestDuration +
+      Math.random() *
+        (config.maximumRequestDuration - config.minimumRequestDuration)
+    setTimeout(() => resolve({ data: `${arg}${nextNumber}` }), duration)
   })
 }
 
 export const api = createApi({
   baseQuery,
   tagTypes: ['QUERY'],
-  endpoints: build => ({
+  endpoints: (build) => ({
     some: build.query({
       query: (arg: string) => arg,
-      providesTags: ['QUERY']
+      providesTags: ['QUERY'],
     }),
-  })
+  }),
 })
 
-export const {useSomeQuery} = api;
+export const { useSomeQuery } = api
 
 export const store = configureStore({
   reducer: {
     [api.reducerPath]: api.reducer,
   },
-  middleware(gDm){
-    return gDm({immutableCheck: false, serializableCheck: false}).concat(api.middleware)
+  middleware(gDm) {
+    return gDm({ immutableCheck: false, serializableCheck: false }).concat(
+      api.middleware
+    )
   },
-  enhancers: (existingEnhancers) => existingEnhancers.concat(autoBatchEnhancer())
-
+  enhancers: (existingEnhancers) =>
+    existingEnhancers.concat(autoBatchEnhancer({ type: 'raf' })),
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -292,10 +292,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@reduxjs/toolkit@1.9.0-rc.0":
-  version "1.9.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.9.0-rc.0.tgz#cdf9cd0584828beed46527ab3675e6d70a0a3efa"
-  integrity sha512-EyCTLBN5wI0F9LAMoY03UtV6EbFiBRIzLEf7ediofCZ19J6aItExAnr3tbqtjD7FuzSHPAVDYY92/5HsKkZYXA==
+"@reduxjs/toolkit@1.9.0-rc.1":
+  version "1.9.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.9.0-rc.1.tgz#e1cf082c18940082520d53d8e1d74121620469eb"
+  integrity sha512-dc4YcvN9aHULyjEXMUFeFGBNeS1XO2m3nRcrk+OGXH+Jgdmep64l4yZtRnayXrFBg492F/+Q1TZoKO8grDkZ1Q==
   dependencies:
     immer "^9.0.7"
     redux "^4.1.2"


### PR DESCRIPTION
After adding the new options for queuing notifications with `setTimeout` and `rAF`, `rAF` seems to have the best balance of UI update behavior.